### PR TITLE
Integrate legacy field extractor into pipeline

### DIFF
--- a/prompt_enhancing/notebooks/exploratory/3.1-Convolutio-complete_pipeline_with_legacy.ipynb
+++ b/prompt_enhancing/notebooks/exploratory/3.1-Convolutio-complete_pipeline_with_legacy.ipynb
@@ -1,0 +1,108 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 3.1 Convolutio - Complete pipeline with legacy fields\n",
+    "\n",
+    "This notebook extends the full pipeline to include the legacy field extractor and logs all steps with MLflow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from archaeo_super_prompt.dataset import MagohDataset, SamplingParams\n",
+    "import archaeo_super_prompt.modeling.train as training\n",
+    "import archaeo_super_prompt.modeling.predict as infering\n",
+    "import mlflow\n",
+    "import pandas as pd\n",
+    "from archaeo_super_prompt.visualization import mlflow_logging as mmlflow\n",
+    "from archaeo_super_prompt.config.env import getenv_or_throw\n",
+    "from sklearn import set_config\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EXP_NAME = \"Legacy field extraction\"\n",
+    "mlflow.set_tracking_uri(f\"http://{getenv_or_throw('MLFLOW_HOST')}:{getenv_or_throw('MLFLOW_PORT')}\")\n",
+    "mlflow.set_experiment(EXP_NAME)\n",
+    "mlflow.dspy.autolog(log_compiles=True, log_evals=True, log_traces_from_compile=True)\n",
+    "pd.set_option('display.max_columns', None)\n",
+    "set_config(display=\"diagram\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dag_parts = training.get_training_dag(include_legacy=True)\n",
+    "expected_final_pipeline = infering.build_complete_inference_dag(dag_parts)\n",
+    "expected_final_pipeline\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = MagohDataset(SamplingParams(size=20, seed=0.1, only_recent_entries=False))\n",
+    "inputs = ds.files.sample(6)\n",
+    "train_inputs, eval_inputs = inputs.iloc[:3], inputs.iloc[3:]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with mlflow.start_run():\n",
+    "    trained_dag_parts = training.train_from_scratch(train_inputs, ds, include_legacy=True)\n",
+    "    per_field_scores, detailed_results = infering.score_dag(trained_dag_parts, eval_inputs, ds)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "detailed_results.head()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- wire legacy MagohDataExtractor into the DAG behind an optional `include_legacy` flag
- add notebook showing the complete pipeline logging legacy field extraction with MLflow

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'archaeo_super_prompt')*

------
https://chatgpt.com/codex/tasks/task_e_68ad8e262a248320be23de4db609877b